### PR TITLE
更换内核并安装破解版锐速

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,19 +41,17 @@ supervisorctl restart shadowsocks
 # 多用户配置文件
 {
             "server":"0.0.0.0",
-            "local_address":"127.0.0.1",
             "local_port":1080,
             "port_password":{
-                               "2333":"fjlag;l556",
-                               "6666":"jgaingga"
-                           },
-              "_comment":{
-                                 "2333":"whouse",
-                                 "6666":"whouse"
-                            },
+                  "2333":"fjlag;l556",
+                  "6666":"jgainggalagj
+            },
+            "_comment":{
+                  "2333":"whouse",
+                  "6666":"whouse"
+            },
             "timeout":300,
-            "method":"chacha20",
-            "fast_open": false
+            "method":"chacha20"
 }
 ```
 

--- a/README.md
+++ b/README.md
@@ -36,8 +36,9 @@ supervisorctl restart shadowsocks
     "method":"chacha20"
 }
 ```
+
+```shell
 # 多用户配置文件
-```
 {
             "server":"0.0.0.0",
             "local_address":"127.0.0.1",

--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ supervisorctl restart shadowsocks
 - 自动生成高强度密码，shadowsocks的配置文件在```/etc/shadowsocks.json```
 - 完成后显示相应的配置文件: 服务器ip，端口，密码等。
 ```shell
-# 显示的配置文件
+# 默认单用户配置显示的配置文件
 {
     "server":"100.100.100.100",
     "server_port":443,
@@ -36,6 +36,26 @@ supervisorctl restart shadowsocks
     "method":"chacha20"
 }
 ```
+# 多用户配置文件
+```
+{
+            "server":"0.0.0.0",
+            "local_address":"127.0.0.1",
+            "local_port":1080,
+            "port_password":{
+                               "2333":"fjlag;l556",
+                               "6666":"jgaingga"
+                           },
+              "_comment":{
+                                 "2333":"whouse",
+                                 "6666":"whouse"
+                            },
+            "timeout":300,
+            "method":"chacha20",
+            "fast_open": false
+}
+```
+
 - 已完成内核参数的优化，默认优化算法是针对高延迟地区的hybla
 
 ## ss-script

--- a/README.md
+++ b/README.md
@@ -67,27 +67,29 @@ curl 'https://raw.githubusercontent.com/keysona/my-script/master/shadowsocks/ss%
 }
 ```
 
-更换内核以支持破解版锐速
+## 替换内核以支持破解版锐速 
 1.安装内核文件：
-
+```
 sudo apt-get install linux-image-extra-3.13.0-29-generic
-
+```
 2.查看当前安装的内核：
-
+```
 dpkg -l|grep linux-image
-
+```
 3.卸载其他内核：
-
+```
 sudo apt-get purge linux-image-3.13.0-xx-generic linux-image-extra-3.13.0-xx-generic
-
+```
 4.更新grub系统引导文件：
-
+```
 sudo update-grub
-
+```
 5.重启系统：
-
+```
 sudo reboot
-
+```
 6.安装破解版锐速
-
-wget -N --no-check-certificate https://raw.githubusercontent.com/91yun/serverspeeder/master/serverspeeder-all.sh && bash serverspeeder-all.sh    
+```
+wget -N --no-check-certificate https://raw.githubusercontent.com/91yun/serverspeeder/master/serverspeeder-all.sh && bash serverspeeder-all.sh
+```
+所有选项一路回车，选择默认即可。

--- a/README.md
+++ b/README.md
@@ -66,3 +66,28 @@ curl 'https://raw.githubusercontent.com/keysona/my-script/master/shadowsocks/ss%
     "method":"chacha20"
 }
 ```
+
+更换内核以支持破解版锐速
+1.安装内核文件：
+
+sudo apt-get install linux-image-extra-3.13.0-29-generic
+
+2.查看当前安装的内核：
+
+dpkg -l|grep linux-image
+
+3.卸载其他内核：
+
+sudo apt-get purge linux-image-3.13.0-xx-generic linux-image-extra-3.13.0-xx-generic
+
+4.更新grub系统引导文件：
+
+sudo update-grub
+
+5.重启系统：
+
+sudo reboot
+
+6.安装破解版锐速
+
+wget -N --no-check-certificate https://raw.githubusercontent.com/91yun/serverspeeder/master/serverspeeder-all.sh && bash serverspeeder-all.sh    


### PR DESCRIPTION
如果锐速不支持当前内核版本，可先更换支持的内核后安装。
